### PR TITLE
Support Benchmark read performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,54 +60,54 @@ Run the application using the following command:
 
 ### Examples
 
-1. List files in the root directory:
+#### 1. List files in the root directory:
 
 ```bash
 ./run.sh hdfs://localhost:9000 list /
 ```
 
-2. Read file content:
+#### 2. Read file content:
 
 ```bash
 ./run.sh hdfs://localhost:9000 read /path/to/file.txt
 ```
 
-3. Write content to a file:
+#### 3. Write content to a file:
 
 ```bash
 ./run.sh hdfs://localhost:9000 write /path/to/file.txt "Hello, HDFS!" true
 ```
 The last parameter `true` indicates whether to overwrite existing files.
 
-4. Create a directory:
+#### 4. Create a directory:
 
 ```bash
 ./run.sh hdfs://localhost:9000 mkdir /path/to/new/directory
 ```
 
-5. Delete a file or directory:
+#### 5. Delete a file or directory:
 
 ```bash
 ./run.sh hdfs://localhost:9000 delete /path/to/delete true
 ```
 The last parameter `true` indicates whether to recursively delete directories.
 
-6. Check if a path exists:
+#### 6. Check if a path exists:
 
 ```bash
 ./run.sh hdfs://localhost:9000 exists /path/to/check
 ```
 
-7. Benchmark read performance:
+#### 7. Benchmark read performance:
    You can use the `benchmarkRead` command to test the read performance of a file or directory using multiple threads.
 
-### 🔧 Usage
+Usage
 
 ```bash
 ./run.sh benchmarkRead <path> <threads>
 ```
 
-### 📌 Parameters
+Parameters
 
 - **`<path>`**:  
   Path to the file or directory to read.  
@@ -121,7 +121,7 @@ The last parameter `true` indicates whether to recursively delete directories.
 > - If `<path>` is a file, each thread will repeatedly read the same file.
 > - If `<path>` is a directory, each thread will read all files in that directory.
 
-### 📎 Example
+ Example
 
 Read the file `/path/to/file.orc` using 20 threads:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,38 @@ The last parameter `true` indicates whether to recursively delete directories.
 ./run.sh hdfs://localhost:9000 exists /path/to/check
 ```
 
+7. Benchmark read performance:
+   You can use the `benchmarkRead` command to test the read performance of a file or directory using multiple threads.
+
+### 🔧 Usage
+
+```bash
+./run.sh benchmarkRead <path> <threads>
+```
+
+### 📌 Parameters
+
+- **`<path>`**:  
+  Path to the file or directory to read.  
+  Supports both local and remote file systems (e.g., HDFS, S3).
+
+- **`<threads>`**:  
+  Number of threads to use for concurrent reading.  
+  Each thread will read all the files independently.
+
+> **Note**:
+> - If `<path>` is a file, each thread will repeatedly read the same file.
+> - If `<path>` is a directory, each thread will read all files in that directory.
+
+### 📎 Example
+
+Read the file `/path/to/file.orc` using 20 threads:
+
+```bash
+./run.sh benchmarkRead hdfs://localhost:9000/path/to/file.orc 20
+```
+
+
 ## Project Structure
 
 - `src/main/java/com/example/hdfs/HdfsClient.java` - Utility class for HDFS operations
@@ -120,6 +152,7 @@ Ensure your Hadoop cluster is running and accessible from the machine where you'
 - `sh run.sh hdfs://hdfs-cluster list hdfs://hdfs-cluster/tmp/`
 - `sh run.sh hdfs://hdfs-cluster write hdfs://hdfs-cluster/tmp/test1.txt "test123"`
 - `sh run.sh hdfs://hdfs-cluster read hdfs://hdfs-cluster/tmp/test1.txt`
+- `run.sh hdfs://hdfs-cluster  benchmarkRead hdfs://hdfs-cluster/tmp/tmp.orc 20`
 
 ### Kerberos & HDFS HA
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <version>${hadoop.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+            <version>1.8</version>
+        </dependency>
         
         <!-- Hadoop HDFS -->
         <dependency>
@@ -49,12 +54,37 @@
             <version>${hadoop.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+            <version>1.1.1</version>
+        </dependency>
 
         <!-- SLF4J API -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <version>3.3.6</version>
         </dependency>
         
         <!-- SLF4J Simple binding for logging -->

--- a/src/main/java/com/example/hdfs/HdfsClientApp.java
+++ b/src/main/java/com/example/hdfs/HdfsClientApp.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class HdfsClientApp {
-
+    
     public static void main(String[] args) {
         if (args.length < 1) {
             System.err.println("Usage: HdfsClientApp <hdfs-uri> [operation] [params...]");
@@ -19,6 +19,7 @@ public class HdfsClientApp {
             System.err.println("  delete <path> [recursive]  - Delete file or directory");
             System.err.println("  exists <path>              - Check if path exists");
             System.err.println("  whoami                     - Show current authenticated user");
+            System.err.println(" benchmarkRead <file/directory-path> [threadCount] [partialRead] [readLimitBytes] - Benchmark concurrent read");
             System.exit(1);
         }
 
@@ -48,6 +49,9 @@ public class HdfsClientApp {
                 case "whoami":
                     whoamiOperation();
                     break;
+                case "benchmarkRead":
+                    benchmarkHdfsConcurrentRead(hdfsClient, args);
+                    break;    
                 default:
                     System.err.println("Unknown operation: " + operation);
                     System.exit(1);
@@ -91,6 +95,22 @@ public class HdfsClientApp {
         
         String filePath = args[2];
         hdfsClient.readFile(filePath);
+    }
+    
+    private static void benchmarkHdfsConcurrentRead(HdfsClient hdfsClient, String[] args) throws IOException, InterruptedException {
+        if (args.length < 3) {
+            System.err.println("Missing file path for benchmark operation");
+            System.exit(1);
+        }
+        
+        String filePath = args[2];
+        int threadCount = args.length > 3 ? Integer.parseInt(args[3]) : 1;
+        
+        boolean partialRead = args.length > 4 && Boolean.parseBoolean(args[4]);
+        
+        long readLimitBytes = args.length > 5 ? Integer.parseInt(args[5]) : 65536;
+        
+        hdfsClient.benchmarkConcurrentRead(filePath, threadCount, partialRead, readLimitBytes);
     }
 
     private static void writeOperation(HdfsClient hdfsClient, String[] args) throws IOException {


### PR DESCRIPTION
run.sh hdfs://jdx-usa  benchmarkRead hdfs://xxx-cluster/user/hive/tmp.orc 20

```
calvinkirs@CalvinKirss-MacBook-Pro hdfs-client-java % bash run.sh hdfs://jdx-usa  benchmarkRead hdfs://xxx-cluster/user/hive/tmp.orc 20

Thread 17 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 261 ms
Thread 9 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 289 ms
Thread 11 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 240 ms
Thread 1 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 338 ms
Thread 19 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 249 ms
Thread 5 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 338 ms
Thread 0 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 390 ms
Thread 13 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 205 ms
Thread 14 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 487 ms
Thread 9 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 179 ms
Thread 2 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 184 ms
Thread 10 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 219 ms
Thread 16 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 502 ms
Thread 8 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 443 ms
Thread 3 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 625 ms
Thread 5 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 118 ms
Thread 4 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00005-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 42133 bytes in 387 ms
Thread 2 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 114 ms
Thread 1 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 278 ms
Thread 13 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 183 ms
Thread 7 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00005-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 42133 bytes in 1236 ms
Thread 3 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 130 ms
Thread 10 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 186 ms
Thread 4 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 135 ms
Thread 7 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 150 ms
Thread 4 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 132 ms
Thread 7 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 133 ms
Thread 15 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 1374 ms
Thread 12 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00006-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43436 bytes in 1353 ms
Thread 12 read file hdfs://jdx-usa/user/hive/tmp.orc/part-00007-18044f6c-c750-41db-8a21-e1f949c14105-c000.zlib.orc: 43203 bytes in 183 ms
All threads completed. Results:
Thread 8 done: 9 files, 343077 bytes, 0 failures, total time 2032 ms

Thread 18 done: 9 files, 343077 bytes, 0 failures, total time 1771 ms

Thread 15 done: 9 files, 343077 bytes, 0 failures, total time 3035 ms

Thread 13 done: 9 files, 343077 bytes, 0 failures, total time 2159 ms

Thread 1 done: 9 files, 343077 bytes, 0 failures, total time 2157 ms

Thread 12 done: 9 files, 343077 bytes, 0 failures, total time 3220 ms

Thread 3 done: 9 files, 343077 bytes, 0 failures, total time 2181 ms

Thread 11 done: 9 files, 343077 bytes, 0 failures, total time 1873 ms

Thread 5 done: 9 files, 343077 bytes, 0 failures, total time 2093 ms

Thread 6 done: 9 files, 343077 bytes, 0 failures, total time 1675 ms

Thread 9 done: 9 files, 343077 bytes, 0 failures, total time 2007 ms

Thread 14 done: 9 files, 343077 bytes, 0 failures, total time 1995 ms

Thread 2 done: 9 files, 343077 bytes, 0 failures, total time 2122 ms

Thread 17 done: 9 files, 343077 bytes, 0 failures, total time 1825 ms

Thread 19 done: 9 files, 343077 bytes, 0 failures, total time 1930 ms

Thread 0 done: 9 files, 343077 bytes, 0 failures, total time 1980 ms

Thread 7 done: 9 files, 343077 bytes, 0 failures, total time 2451 ms

Thread 4 done: 9 files, 343077 bytes, 0 failures, total time 2362 ms

Thread 16 done: 9 files, 343077 bytes, 0 failures, total time 2010 ms

Thread 10 done: 9 files, 343077 bytes, 0 failures, total time 2197 ms

TOTAL: 180 files, 6861540 bytes read, 0 failed
HDFS client closed


```